### PR TITLE
DR2-1158 feat: Add ingest mapper lambda.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: DR2 Tag and pre deploy
+on:
+  push:
+    branches:
+      - main
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  pre-deploy:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_build.yml@main
+    with:
+      repo-name: dr2-ingest-mapper
+      artifact-name: dr2-ingest-mapper
+      build-command: sbt assembly
+    secrets:
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  deploy:
+    needs: pre-deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: DR2 Deploy DR2 Ingest Mapper Lambda
+name: Deploy DR2 Ingest Mapper Lambda
 on:
   workflow_dispatch:
     inputs:
@@ -23,7 +23,7 @@ jobs:
     uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_deploy.yml@main
     with:
       lambda-name: ${{ github.event.inputs.environment }}-dr2-ingest-mapper
-      deployment-package: notifications_lambda.zip
+      deployment-package: dr2-ingest-mapper.jar
       environment: ${{ github.event.inputs.environment }}
       to-deploy: ${{ github.event.inputs.to-deploy }}
     secrets:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: DR2 Deploy DR2 Ingest Mapper Lambda
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: 'Environment'
+        required: true
+        options:
+          - intg
+          - staging
+          - prod
+        default: 'intg'
+      to-deploy:
+        description: 'Version to deploy'
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  deploy:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_deploy.yml@main
+    with:
+      lambda-name: ${{ github.event.inputs.environment }}-dr2-ingest-mapper
+      deployment-package: notifications_lambda.zip
+      environment: ${{ github.event.inputs.environment }}
+      to-deploy: ${{ github.event.inputs.to-deploy }}
+    secrets:
+      ACCOUNT_NUMBER: ${{ secrets.ACCOUNT_NUMBER }}
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: DR2 Run Lambda Tests
+on:
+  push:
+    branches-ignore:
+      - main
+      - release-*
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  test:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/dr2_test.yml@main
+    with:
+      repo-name: dr2-ingest-mapper
+      test-command: sbt scalafmtCheckAll test
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# macOS
+.DS_Store
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+.ensime
+.ensime_cache/
+.sbt-scripted/
+local.sbt
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/softwaremill/scala-pre-commit-hooks
+    rev: v0.3.0
+    default_phase: commit
+    hooks:
+      - id: sbt-scalafmt

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,4 @@
+version = 3.7.3
+preset = default
+runner.dialect = scala213
+maxColumn = 170

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The National Archives, UK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # DR2 Ingest Mapper
+
+This lambda reads a bagit package based on the input to the lambda, parses file metadata and writes this to a DynamoDB table.
+
+The lambda:
+* Reads the input from the step function step with this format:
+```json
+{
+  "batchId": "batch",
+  "s3Bucket": "bucket",
+  "s3Prefix": "prefix/",
+  "department": "departmnet",
+  "series": "series"
+}
+```
+* Gets the title and description for department and series from discovery. This is run through the XSLT in `src/main/resources/transform.xsl` to replace the EAD tags with newlines.
+* Parses the folder metadata csv
+* Parses the asset metadata csv
+* Parses the file metadata csv
+* Parses the manifest file
+* Converts these into Dynamo case classes
+```scala
+  case class DynamoTable(
+      batchId: String,
+      id: UUID,
+      parentPath: String,
+      name: String,
+      `type`: String,
+      title: String,
+      description: String,
+      fileSize: Option[Long] = None,
+      checksumSha256: Option[String] = None,
+      fileExtension: Option[String] = None
+  )
+```
+* Updates dynamo with the values
+* Writes the state data for the next step function step with this format:
+```json
+{
+  "batchId": "TDR-2023-ABC",
+  "rootPath": "s3://<env>-dr2-ingest-raw-cache/TDR-2023-ABC/",
+  "batchType": "courtDocument",
+  "archiveHierarchyFolders": [
+      "f0d3d09a-5e3e-42d0-8c0d-3b2202f0e176",
+      "e88e433a-1f3e-48c5-b15f-234c0e663c27",
+      "93f5a200-9ee7-423d-827c-aad823182ad2"
+  ],
+  "contentFolders": [],
+  "contentAssets": [
+      "a8163bde-7daa-43a7-9363-644f93fe2f2b"
+  ]
+}
+```
+
+
+
+[Link to the infrastructure code](https://github.com/nationalarchives/dp-terraform-environments/blob/main/ingest_mapper.tf)
+
+## Environment Variables
+
+| Name              | Description                      |
+|-------------------|----------------------------------|
+| DYNAMO_TABLE_NAME | The table to write the values to |

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,40 @@
+import Dependencies._
+import uk.gov.nationalarchives.sbt.Log4j2MergePlugin.log4j2MergeStrategy
+
+ThisBuild / organization := "uk.gov.nationalarchives"
+ThisBuild / scalaVersion := "2.13.10"
+
+lazy val root = (project in file(".")).
+  settings(
+    name := "dr2-ingest-mapper",
+    libraryDependencies ++= Seq(
+      fs2Csv,
+      fs2CsvGeneric,
+      fs2Reactive,
+      log4jSlf4j,
+      log4jCore,
+      log4jTemplateJson,
+      lambdaCore,
+      pureConfig,
+      pureConfigCats,
+      s3Client,
+      dynamoClient,
+      scalaXml,
+      sttp,
+      sttpUpickle,
+      "io.projectreactor" % "reactor-test" % "3.5.4" % Test,
+      scalaTest % Test,
+      mockito % Test,
+      wiremock % Test
+    )
+  )
+(assembly / assemblyJarName) := "dr2-ingest-mapper.jar"
+
+scalacOptions ++= Seq("-Wunused:imports", "-Werror")
+ThisBuild/scalacOptions ++= Seq("-unchecked", "-deprecation")
+
+(assembly / assemblyMergeStrategy) := {
+  case PathList(ps@_*) if ps.last == "Log4j2Plugins.dat" => log4j2MergeStrategy
+  case _ => MergeStrategy.first
+}
+

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import uk.gov.nationalarchives.sbt.Log4j2MergePlugin.log4j2MergeStrategy
 
 ThisBuild / organization := "uk.gov.nationalarchives"
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.11"
 
 lazy val root = (project in file(".")).
   settings(

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="JsonAppender" target="SYSTEM_OUT">
+            <JsonTemplateLayout />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="JsonLogger" level="INFO" additivity="false">
+            <AppenderRef ref="JsonAppender"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="JsonAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val pureConfigCats = "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.17.4"
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.4"
   lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % awsClientVersion
-  lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.17-SNAPSHOT"
+  lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.17"
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.17.12"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,22 @@
+import sbt._
+object Dependencies {
+  lazy val logbackVersion = "2.20.0"
+  lazy val awsClientVersion = "0.1.16"
+  lazy val fs2Reactive = "co.fs2" %% "fs2-reactive-streams" % "3.7.0"
+  lazy val fs2Csv = "org.gnieh" %% "fs2-data-csv" % "1.8.0"
+  lazy val fs2CsvGeneric = "org.gnieh" %% "fs2-data-csv-generic" % "1.8.0"
+  lazy val log4jSlf4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % logbackVersion
+  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core" % logbackVersion
+  lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
+  lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
+  lazy val pureConfigCats = "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.17.4"
+  lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.4"
+  lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % awsClientVersion
+  lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.17-SNAPSHOT"
+  lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
+  lazy val mockito = "org.mockito" %% "mockito-scala" % "1.17.12"
+  lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"
+  lazy val sttp = "com.softwaremill.sttp.client3" %% "fs2" % "3.8.16"
+  lazy val sttpUpickle = "com.softwaremill.sttp.client3" %% "upickle" % "3.8.16"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.1
+sbt.version=1.9.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("uk.gov.nationalarchives" % "sbt-assembly-log4j2" % "0.0.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("uk.gov.nationalarchives" % "sbt-assembly-log4j2" % "0.0.2")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,2 @@
+dynamo-table-name = ${DYNAMO_TABLE_NAME}
+discovery-api-url = "https://discovery.nationalarchives.gov.uk"

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = warn
+
+name = DR2LambdaLogConfiguration
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.json.type = JsonTemplateLayout
+
+rootLogger.level = info
+
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/src/main/resources/transform.xsl
+++ b/src/main/resources/transform.xsl
@@ -1,0 +1,641 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="html" omit-xml-declaration="yes" />
+
+    <xsl:template match="XMLFragment">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="scopecontent">
+        <xsl:apply-templates />
+    </xsl:template>
+
+
+    <xsl:template match="bioghist">
+        <div>
+            <xsl:apply-templates />
+        </div>
+    </xsl:template>
+
+    <xsl:template match="arrangement">
+        <div>
+            <xsl:apply-templates />
+        </div>
+    </xsl:template>
+
+    <xsl:template match="unittitle">
+        <div>
+            <xsl:apply-templates />
+        </div>
+    </xsl:template>
+
+    <xsl:template match="archref">
+        <xsl:choose>
+            <xsl:when test="@href!=''">
+                <xsl:value-of select="@href"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="extref">
+        <xsl:choose>
+            <xsl:when test="@href!=''">
+                <xsl:value-of select="@href"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="ref">
+        <xsl:choose>
+            <xsl:when test="@href!='' and not(@target)">
+                <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="table">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="chronlist">
+        <table>
+            <xsl:for-each select="chronitem">
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:apply-templates />
+            </xsl:for-each>
+        </table>
+    </xsl:template>
+
+    <xsl:template match="list">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="list/item">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="emph">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="title">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="lb">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:template>
+
+    <xsl:template match="p" name="p">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="note">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="blockquote">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="abbr">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="abstract">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="accruals">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="acqinfo">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="address">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="addressline">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="add">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="admininfo">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="altformavail">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="appraisal">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="archdesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="archdescgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="author">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="bibref">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="bibseries">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="bibliography">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="change">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="chronitem">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c08">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c11">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c05">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c01">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c04">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c09">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c02">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c07">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c06">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c10">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c03">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c12">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="c">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="container">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="controlaccess">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="corpname">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="creation">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="custodhist">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="date">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="unitdate">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="defitem">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="dsc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="dscgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="did">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="dao">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="daodesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="daogrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="daoloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="dimensions">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="dentry">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="drow">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="eadgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="eadheader">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="eadid">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="edition">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="editionstmt">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="ead">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="event">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="eventgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="expan">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="extptr">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="exptrloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="extrefloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="extent">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="famname">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="filedesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="fileplan">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="head01">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="frontmatter">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="function">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="genreform">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="geogname">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="head">
+    </xsl:template>
+
+    <xsl:template match="unitid">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="imprint">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="index">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="indexentry">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="label">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="language">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="langusage">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="scopecontent/language">
+        <p>
+            <xsl:apply-templates />
+        </p>
+    </xsl:template>
+
+    <xsl:template match="linkgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="listhead">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="name">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="namegrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="notestmt">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="num">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="occupation">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="organization">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="origination">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="odd">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="otherfindaid">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="persname">
+        <xsl:choose>
+            <xsl:when test="emph">
+                <xsl:for-each select="child::emph">
+                    <xsl:apply-templates />
+                    <xsl:if test="position() != last()">
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="physdesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="physloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="ptr">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="ptrgrp">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="ptrloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="prefercite">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="processinfo">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="profiledesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="publicationstmt">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="publisher">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="reloc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="relatedmaterial">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="repository">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="accessrestrict">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="userrestrict">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="revisiondesc">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="runner">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="head02">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="seperatedmaterial">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="seriesstmt">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="spanspec">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="sponsor">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="subject">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="subarea">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="subtitle">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="tbody">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="colspec">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="entry">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="tfoot">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="tgroup">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="thead">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="row">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="tspec">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="div">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="titlepage">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="titleproper">
+        <xsl:apply-templates />
+    </xsl:template>
+
+    <xsl:template match="titletmt">
+        <xsl:apply-templates />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -1,0 +1,87 @@
+package uk.gov.nationalarchives
+
+import cats.effect.{IO, Resource}
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3.httpclient.fs2.HttpClientFs2Backend
+import sttp.client3.upicklejson.asJson
+import sttp.client3.{SttpBackend, UriContext, basicRequest}
+import uk.gov.nationalarchives.DiscoveryService._
+import uk.gov.nationalarchives.Lambda.Input
+import uk.gov.nationalarchives.MetadataService.{DepartmentSeries, DynamoTable}
+import upickle.default._
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.UUID
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.stream.{StreamResult, StreamSource}
+import scala.xml.XML
+
+class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Streams[IO]], randomUuidGenerator: () => UUID) {
+  private val folder = "Folder"
+
+  private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryAsset) = {
+    val resources = for {
+      xsltStream <- Resource.make(IO(getClass.getResourceAsStream("/transform.xsl")))(is => IO(is.close()))
+      inputStream <- Resource.make(IO(new ByteArrayInputStream(discoveryAsset.scopeContent.description.getBytes())))(is => IO(is.close()))
+      outputStream <- Resource.make(IO(new ByteArrayOutputStream()))(bos => IO(bos.close()))
+    } yield {
+      (xsltStream, inputStream, outputStream)
+    }
+    resources.use {
+      case (xsltStream, inputStream, outputStream) =>
+        val factory = TransformerFactory.newInstance()
+        val xslt = new StreamSource(xsltStream)
+        val input = new StreamSource(inputStream)
+        val result = new StreamResult(outputStream)
+        val transformer = factory.newTransformer(xslt)
+        transformer.transform(input, result)
+        val newDescription = outputStream.toByteArray.map(_.toChar).mkString.trim
+        val scopeContent = discoveryAsset.scopeContent.copy(description = newDescription)
+        val newTitle = XML.loadString(discoveryAsset.title.replaceAll("\\\\", "")).text
+        IO(discoveryAsset.copy(scopeContent = scopeContent, title = newTitle)).handleError(_ => discoveryAsset)
+      case _ => IO(discoveryAsset)
+    }
+  }
+
+  private def callDiscoveryApi(citableReference: String): IO[DiscoveryAsset] = {
+    val uri = uri"$discoveryBaseUrl/API/records/v1/collection/$citableReference"
+    val request = basicRequest.get(uri).response(asJson[DiscoveryResponse])
+    for {
+      response <- backend.send(request)
+      body <- IO.fromEither(response.body)
+      asset <- IO.fromOption(body.assets.find(_.citableReference == citableReference))(
+        new Exception(s"Cannot find asset with citeable reference $citableReference")
+      )
+      formattedAsset <- stripHtmlFromDiscoveryResponse(asset)
+    } yield formattedAsset
+  }
+
+  def getDepartmentAndSeriesRows(input: Input): IO[DepartmentSeries] = {
+    def tableEntry(asset: DiscoveryAsset) =
+      DynamoTable(input.batchId, randomUuidGenerator(), "", asset.citableReference, folder, asset.title, asset.scopeContent.description)
+
+    for {
+      department <- input.department
+      series <- input.series
+    } yield for {
+      discoveryDepartment <- callDiscoveryApi(department)
+      discoverySeries <- callDiscoveryApi(series)
+    } yield {
+      val departmentEntry = tableEntry(discoveryDepartment)
+      DepartmentSeries(departmentEntry, Option(tableEntry(discoverySeries).copy(parentPath = departmentEntry.id.toString)))
+    }
+  }.getOrElse(IO(DepartmentSeries(DynamoTable(input.batchId, randomUuidGenerator(), "", "Unknown", folder, "", ""), None)))
+}
+object DiscoveryService {
+  case class DiscoveryScopeContent(description: String)
+  case class DiscoveryAsset(citableReference: String, scopeContent: DiscoveryScopeContent, title: String)
+  case class DiscoveryResponse(assets: List[DiscoveryAsset])
+
+  implicit val discoverScopeContentReader: Reader[DiscoveryScopeContent] = macroR[DiscoveryScopeContent]
+  implicit val discoveryAssetReader: Reader[DiscoveryAsset] = macroR[DiscoveryAsset]
+  implicit val discoveryResponseReader: Reader[DiscoveryResponse] = macroR[DiscoveryResponse]
+
+  def apply(discoveryUrl: String, randomUuidGenerator: () => UUID): IO[DiscoveryService] = HttpClientFs2Backend.resource[IO]().use { backend =>
+    IO(new DiscoveryService(discoveryUrl, backend, randomUuidGenerator))
+  }
+}

--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -1,13 +1,14 @@
 package uk.gov.nationalarchives
 
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import sttp.client3.upicklejson.asJson
 import sttp.client3.{SttpBackend, UriContext, basicRequest}
 import uk.gov.nationalarchives.DiscoveryService._
 import uk.gov.nationalarchives.Lambda.Input
-import uk.gov.nationalarchives.MetadataService.{DepartmentSeries, DynamoTable}
+import uk.gov.nationalarchives.MetadataService.{DepartmentAndSeriesTableData, DynamoTable, Folder}
 import upickle.default._
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
@@ -17,16 +18,14 @@ import javax.xml.transform.stream.{StreamResult, StreamSource}
 import scala.xml.XML
 
 class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Streams[IO]], randomUuidGenerator: () => UUID) {
-  private val folder = "Folder"
+  private val folder = Folder()
 
-  private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryAsset) = {
+  private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryCollectionAsset) = {
     val resources = for {
       xsltStream <- Resource.make(IO(getClass.getResourceAsStream("/transform.xsl")))(is => IO(is.close()))
       inputStream <- Resource.make(IO(new ByteArrayInputStream(discoveryAsset.scopeContent.description.getBytes())))(is => IO(is.close()))
       outputStream <- Resource.make(IO(new ByteArrayOutputStream()))(bos => IO(bos.close()))
-    } yield {
-      (xsltStream, inputStream, outputStream)
-    }
+    } yield (xsltStream, inputStream, outputStream)
     resources.use {
       case (xsltStream, inputStream, outputStream) =>
         val factory = TransformerFactory.newInstance()
@@ -36,50 +35,51 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
         val transformer = factory.newTransformer(xslt)
         transformer.transform(input, result)
         val newDescription = outputStream.toByteArray.map(_.toChar).mkString.trim
-        val scopeContent = discoveryAsset.scopeContent.copy(description = newDescription)
-        val newTitle = XML.loadString(discoveryAsset.title.replaceAll("\\\\", "")).text
-        IO(discoveryAsset.copy(scopeContent = scopeContent, title = newTitle)).handleError(_ => discoveryAsset)
+        val scopeContentWithNewDescription = discoveryAsset.scopeContent.copy(description = newDescription)
+        val titleWithoutBackslashes = XML.loadString(discoveryAsset.title.replaceAll("\\\\", "")).text
+        IO(discoveryAsset.copy(scopeContent = scopeContentWithNewDescription, title = titleWithoutBackslashes)).handleError(_ => discoveryAsset)
       case _ => IO(discoveryAsset)
     }
   }
 
-  private def callDiscoveryApi(citableReference: String): IO[DiscoveryAsset] = {
+  private def getAssetFromDiscoveryApi(citableReference: String): IO[DiscoveryCollectionAsset] = {
     val uri = uri"$discoveryBaseUrl/API/records/v1/collection/$citableReference"
-    val request = basicRequest.get(uri).response(asJson[DiscoveryResponse])
+    val request = basicRequest.get(uri).response(asJson[DiscoveryCollectionAssetResponse])
     for {
       response <- backend.send(request)
       body <- IO.fromEither(response.body)
       asset <- IO.fromOption(body.assets.find(_.citableReference == citableReference))(
-        new Exception(s"Cannot find asset with citeable reference $citableReference")
+        new Exception(s"Cannot find asset with citable reference $citableReference")
       )
       formattedAsset <- stripHtmlFromDiscoveryResponse(asset)
     } yield formattedAsset
   }
 
-  def getDepartmentAndSeriesRows(input: Input): IO[DepartmentSeries] = {
-    def tableEntry(asset: DiscoveryAsset) =
+  def getDepartmentAndSeriesRows(input: Input): IO[DepartmentAndSeriesTableData] = {
+    def tableEntry(asset: DiscoveryCollectionAsset) =
       DynamoTable(input.batchId, randomUuidGenerator(), "", asset.citableReference, folder, asset.title, asset.scopeContent.description)
-
     for {
-      department <- input.department
-      series <- input.series
-    } yield for {
-      discoveryDepartment <- callDiscoveryApi(department)
-      discoverySeries <- callDiscoveryApi(series)
+      departmentDiscoveryAsset <- input.department.map(getAssetFromDiscoveryApi).sequence
+      seriesDiscoveryAsset <- input.series.map(getAssetFromDiscoveryApi).sequence
     } yield {
-      val departmentEntry = tableEntry(discoveryDepartment)
-      DepartmentSeries(departmentEntry, Option(tableEntry(discoverySeries).copy(parentPath = departmentEntry.id.toString)))
+      val departmentTableEntry = departmentDiscoveryAsset
+        .map(tableEntry)
+        .getOrElse(DynamoTable(input.batchId, randomUuidGenerator(), "", "Unknown", folder, "", ""))
+      val seriesTableEntryOpt = seriesDiscoveryAsset
+        .map(tableEntry)
+        .map(_.copy(parentPath = departmentTableEntry.id.toString))
+      DepartmentAndSeriesTableData(departmentTableEntry, seriesTableEntryOpt)
     }
-  }.getOrElse(IO(DepartmentSeries(DynamoTable(input.batchId, randomUuidGenerator(), "", "Unknown", folder, "", ""), None)))
+  }
 }
 object DiscoveryService {
   case class DiscoveryScopeContent(description: String)
-  case class DiscoveryAsset(citableReference: String, scopeContent: DiscoveryScopeContent, title: String)
-  case class DiscoveryResponse(assets: List[DiscoveryAsset])
+  case class DiscoveryCollectionAsset(citableReference: String, scopeContent: DiscoveryScopeContent, title: String)
+  case class DiscoveryCollectionAssetResponse(assets: List[DiscoveryCollectionAsset])
 
   implicit val discoverScopeContentReader: Reader[DiscoveryScopeContent] = macroR[DiscoveryScopeContent]
-  implicit val discoveryAssetReader: Reader[DiscoveryAsset] = macroR[DiscoveryAsset]
-  implicit val discoveryResponseReader: Reader[DiscoveryResponse] = macroR[DiscoveryResponse]
+  implicit val discoveryAssetReader: Reader[DiscoveryCollectionAsset] = macroR[DiscoveryCollectionAsset]
+  implicit val discoveryResponseReader: Reader[DiscoveryCollectionAssetResponse] = macroR[DiscoveryCollectionAssetResponse]
 
   def apply(discoveryUrl: String, randomUuidGenerator: () => UUID): IO[DiscoveryService] = HttpClientFs2Backend.resource[IO]().use { backend =>
     IO(new DiscoveryService(discoveryUrl, backend, randomUuidGenerator))

--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -18,7 +18,7 @@ import javax.xml.transform.stream.{StreamResult, StreamSource}
 import scala.xml.XML
 
 class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Streams[IO]], randomUuidGenerator: () => UUID) {
-  private val folder = Folder()
+  private val folder = Folder
 
   private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryCollectionAsset) = {
     val resources = for {

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,0 +1,77 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import fs2.data.csv._
+import fs2.data.csv.generic.semiauto._
+import org.scanamo.generic.auto._
+import pureconfig._
+import pureconfig.generic.auto._
+import pureconfig.module.catseffect.syntax._
+import ujson.{Null, Value}
+import uk.gov.nationalarchives.Lambda.{Config, _}
+import uk.gov.nationalarchives.MetadataService.{AssetMetadata, BagitManifest, FileMetadata, FolderMetadata}
+import upickle.default
+import upickle.default._
+
+import java.io.{InputStream, OutputStream}
+import java.util.UUID
+
+class Lambda extends RequestStreamHandler {
+  val metadataService: MetadataService = MetadataService()
+  val dynamo: DADynamoDBClient[IO] = DADynamoDBClient[IO]()
+  val randomUuidGenerator: () => UUID = () => UUID.randomUUID()
+
+  implicit val inputReader: Reader[Input] = macroR[Input]
+  implicit val folderMetadataRowDecoder: CsvRowDecoder[FolderMetadata, String] = deriveCsvRowDecoder
+  implicit val assetMetadataRowDecoder: CsvRowDecoder[AssetMetadata, String] = deriveCsvRowDecoder
+  implicit val fileMetadataRowDecoder: CsvRowDecoder[FileMetadata, String] = deriveCsvRowDecoder
+  implicit val bagManifestRowDecoder: RowDecoder[BagitManifest] = deriveRowDecoder
+
+  implicit def OptionReader[T: Reader]: Reader[Option[T]] = reader[Value].map[Option[T]] {
+    case Null    => None
+    case jsValue => Some(read[T](jsValue))
+  }
+
+  implicit def OptionWriter[T: Writer]: Writer[Option[T]] = writer[Value].comap {
+    case Some(value) => write(value)
+    case None        => Null
+  }
+
+  override def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    val inputString = inputStream.readAllBytes().map(_.toChar).mkString
+    val input = read[Input](inputString)
+    for {
+      config <- ConfigSource.default.loadF[IO, Config]()
+      discoveryService <- DiscoveryService(config.discoveryApiUrl, randomUuidGenerator)
+      departmentAndSeries <- discoveryService.getDepartmentAndSeriesRows(input)
+      folderMetadata <- metadataService.parseCsvWithHeaders[FolderMetadata](input, "folder-metadata.csv")
+      assetMetadata <- metadataService.parseCsvWithHeaders[AssetMetadata](input, "asset-metadata.csv")
+      fileMetadata <- metadataService.parseCsvWithHeaders[FileMetadata](input, "file-metadata.csv")
+      bagManifests <- metadataService.parseCsvWithoutHeaders[BagitManifest](input, "manifest-sha256.txt")
+      entries <- metadataService.metadataToDynamoTables(input.batchId, departmentAndSeries, folderMetadata ++ assetMetadata ++ fileMetadata, bagManifests)
+      _ <- dynamo.putItems(config.dynamoTableName, entries)
+    } yield {
+      val folderMetadataIds: List[UUID] = folderMetadata.filter(fm => fm.title != fm.name).map(_.identifier)
+      val departmentSeriesIds: List[UUID] = departmentAndSeries.department.id :: departmentAndSeries.series.map(_.id).toList
+
+      val stateData = StateData(
+        input.batchId,
+        input.s3Bucket,
+        input.s3Prefix,
+        folderMetadataIds ++ departmentSeriesIds,
+        folderMetadata.filter(fm => fm.title == fm.name).map(_.identifier),
+        assetMetadata.map(_.identifier)
+      )
+      outputStream.write(write(stateData).getBytes())
+    }
+  }.unsafeRunSync()
+
+}
+object Lambda {
+  implicit val stateDataWriter: default.Writer[StateData] = macroW[StateData]
+  case class StateData(batchId: String, s3Bucket: String, s3Prefix: String, archiveHierarchyFolders: List[UUID], contentFolders: List[UUID], contentAssets: List[UUID])
+  case class Input(batchId: String, s3Bucket: String, s3Prefix: String, department: Option[String], series: Option[String])
+  case class Config(dynamoTableName: String, discoveryApiUrl: String)
+}

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -47,7 +47,7 @@ class Lambda extends RequestStreamHandler {
       case "File"     => Right(File())
       case typeString => Left(TypeCoercionError(new Exception(s"Type $typeString not found")))
     },
-    typeCaseClass => typeCaseClass.value
+    typeCaseClass => typeCaseClass.getClass.getSimpleName
   )
 
   implicit val dynamoTableFormat: Typeclass[DynamoTable] = deriveDynamoFormat[DynamoTable]

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -51,7 +51,7 @@ class Lambda extends RequestStreamHandler {
       fileMetadata <- metadataService.parseCsvWithHeaders[FileMetadata](input, "file-metadata.csv")
       bagManifests <- metadataService.parseCsvWithoutHeaders[BagitManifest](input, "manifest-sha256.txt")
       entries <- metadataService.metadataToDynamoTables(input.batchId, departmentAndSeries, folderMetadata ++ assetMetadata ++ fileMetadata, bagManifests)
-      _ <- dynamo.putItems(config.dynamoTableName, entries)
+      _ <- dynamo.writeItems(config.dynamoTableName, entries)
     } yield {
       val folderMetadataIds: List[UUID] = folderMetadata.filter(fm => fm.title != fm.name).map(_.identifier)
       val departmentSeriesIds: List[UUID] = departmentAndSeries.department.id :: departmentAndSeries.series.map(_.id).toList

--- a/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
@@ -1,0 +1,99 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import fs2.data.csv._
+import fs2.interop.reactivestreams._
+import fs2.{Chunk, Pipe, Stream, text}
+import uk.gov.nationalarchives.Lambda.Input
+import uk.gov.nationalarchives.MetadataService._
+
+import java.util.UUID
+
+class MetadataService(s3: DAS3Client[IO]) {
+  def parseCsvWithHeaders[T](input: Input, name: String)(implicit decoder: CsvRowDecoder[T, String]): IO[List[T]] = {
+    parseCsv(input, name, decodeUsingHeaders[T]())
+  }
+
+  def parseCsvWithoutHeaders[T](input: Input, name: String)(implicit decoder: RowDecoder[T]): IO[List[T]] = {
+    parseCsv(input, name, decodeWithoutHeaders[T](' '))
+  }
+
+  private def parseCsv[T](input: Input, name: String, decoderPipe: Pipe[IO, String, T]): IO[List[T]] = {
+    for {
+      pub <- s3.download(input.s3Bucket, s"${input.s3Prefix}$name")
+      csvString <- pub
+        .toStreamBuffered[IO](1024 * 5)
+        .flatMap(bf => Stream.chunk(Chunk.byteBuffer(bf)))
+        .through(text.utf8.decode)
+        .through(decoderPipe)
+        .compile
+        .toList
+    } yield csvString
+  }
+
+  def metadataToDynamoTables(
+      batchId: String,
+      departmentAndSeries: DepartmentSeries,
+      metadata: List[Metadata],
+      bagitManifests: List[BagitManifest]
+  ): IO[List[DynamoTable]] = {
+    val fileIdToChecksum: Map[UUID, String] = bagitManifests.map(bm => UUID.fromString(bm.filePath.stripPrefix("data/")) -> bm.checksum).toMap
+    val pathPrefix = departmentAndSeries.series
+      .map(series => s"${departmentAndSeries.department.id}/${series.id}")
+      .getOrElse(s"${departmentAndSeries.department.id}")
+    IO {
+      departmentAndSeries.department ::
+        metadata.map {
+          case AssetMetadata(identifier, parentPath, title) =>
+            DynamoTable(batchId, identifier, s"$pathPrefix/${parentPath.stripPrefix("/")}", title, "Asset", "", "")
+          case FileMetadata(identifier, parentPath, name, fileSize, title) =>
+            DynamoTable(
+              batchId,
+              identifier,
+              s"$pathPrefix/${parentPath.stripPrefix("/")}",
+              name,
+              "File",
+              title,
+              "",
+              Option(fileSize),
+              fileIdToChecksum.get(identifier),
+              name.split("\\.").lastOption
+            )
+          case FolderMetadata(identifier, parentPath, name, title) =>
+            DynamoTable(batchId, identifier, s"$pathPrefix/${parentPath.stripPrefix("/")}", name, "Folder", title, "")
+        } ++ departmentAndSeries.series.toList
+
+    }
+  }
+}
+object MetadataService {
+  trait Metadata
+
+  case class DynamoTable(
+      batchId: String,
+      id: UUID,
+      parentPath: String,
+      name: String,
+      `type`: String,
+      title: String,
+      description: String,
+      fileSize: Option[Long] = None,
+      checksumSha256: Option[String] = None,
+      fileExtension: Option[String] = None
+  )
+
+  case class FolderMetadata(identifier: UUID, parentPath: String, name: String, title: String) extends Metadata
+
+  case class AssetMetadata(identifier: UUID, parentPath: String, title: String) extends Metadata
+
+  case class FileMetadata(identifier: UUID, parentPath: String, name: String, fileSize: Long, title: String) extends Metadata
+
+  case class BagitManifest(checksum: String, filePath: String)
+
+  case class DepartmentSeries(department: DynamoTable, series: Option[DynamoTable])
+
+  def apply(): MetadataService = {
+    val s3 = DAS3Client[IO]()
+    new MetadataService(s3)
+  }
+}

--- a/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
@@ -70,18 +70,10 @@ class MetadataService(s3: DAS3Client[IO]) {
   }
 }
 object MetadataService {
-  sealed trait Type {
-    def value: String
-  }
-  case class Folder() extends Type {
-    override def value: String = "Folder"
-  }
-  case class Asset() extends Type {
-    override def value: String = "Asset"
-  }
-  case class File() extends Type {
-    override def value: String = "File"
-  }
+  sealed trait Type
+  case class Folder() extends Type
+  case class Asset() extends Type
+  case class File() extends Type
 
   sealed trait Metadata {
     def identifier: UUID

--- a/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
@@ -47,14 +47,14 @@ class MetadataService(s3: DAS3Client[IO]) {
       departmentAndSeries.department ::
         metadata.map {
           case AssetMetadata(identifier, parentPath, title) =>
-            DynamoTable(batchId, identifier, s"$pathPrefix/${parentPath.stripPrefix("/")}", title, Asset(), "", "")
+            DynamoTable(batchId, identifier, s"$pathPrefix/${parentPath.stripPrefix("/")}", title, Asset, "", "")
           case FileMetadata(identifier, parentPath, name, fileSize, title) =>
             DynamoTable(
               batchId,
               identifier,
               s"$pathPrefix/${parentPath.stripPrefix("/")}",
               name,
-              File(),
+              File,
               title,
               "",
               Option(fileSize),
@@ -63,17 +63,23 @@ class MetadataService(s3: DAS3Client[IO]) {
             )
           case FolderMetadata(identifier, parentPath, name, title) =>
             val path = if (parentPath.isEmpty) pathPrefix else s"$pathPrefix/${parentPath.stripPrefix("/")}"
-            DynamoTable(batchId, identifier, path, name, Folder(), title, "")
+            DynamoTable(batchId, identifier, path, name, Folder, title, "")
         } ++ departmentAndSeries.series.toList
 
     }
   }
 }
 object MetadataService {
-  sealed trait Type
-  case class Folder() extends Type
-  case class Asset() extends Type
-  case class File() extends Type
+  sealed trait Type {
+    override def toString: String = this match {
+      case Folder => "Folder"
+      case Asset  => "Asset"
+      case File   => "File"
+    }
+  }
+  case object Folder extends Type
+  case object Asset extends Type
+  case object File extends Type
 
   sealed trait Metadata {
     def identifier: UUID

--- a/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
@@ -60,7 +60,8 @@ class MetadataService(s3: DAS3Client[IO]) {
               name.split("\\.").lastOption
             )
           case FolderMetadata(identifier, parentPath, name, title) =>
-            DynamoTable(batchId, identifier, s"$pathPrefix/${parentPath.stripPrefix("/")}", name, "Folder", title, "")
+            val path = if (parentPath.isEmpty) pathPrefix else s"$pathPrefix/${parentPath.stripPrefix("/")}"
+            DynamoTable(batchId, identifier, path, name, "Folder", title, "")
         } ++ departmentAndSeries.series.toList
 
     }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,2 @@
+dynamo-table-name = test
+discovery-api-url = "http://localhost:9004"

--- a/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
@@ -1,0 +1,156 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import cats.effect.IO.asyncForIO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3.UriContext
+import sttp.client3.impl.cats.CatsMonadError
+import sttp.client3.testing.SttpBackendStub
+import uk.gov.nationalarchives.Lambda.Input
+import uk.gov.nationalarchives.MetadataService.DynamoTable
+
+import java.util.UUID
+
+class DiscoveryServiceTest extends AnyFlatSpec {
+
+  val uuids: List[String] = List(
+    "c7e6b27f-5778-4da8-9b83-1b64bbccbd03",
+    "61ac0166-ccdf-48c4-800f-29e5fba2efda",
+    "457cc27d-5b74-4e81-80e3-d808e0b3e425",
+    "2b9e5c87-2342-4006-b1aa-5308a5ce2544"
+  )
+
+  val uuidsIterator: Iterator[String] = uuids.iterator
+  val uuidIterator: () => UUID = () => {
+    UUID.fromString(uuidsIterator.next())
+  }
+
+  val baseUrl = "http://localhost"
+  val bodyMap: Map[String, String] = List("T", "T TEST")
+    .map(col => {
+      val description = <scopecontent>
+        <head>Head</head>
+        <p><list>
+          <item>TestDescription {col} 1</item>
+          <item>TestDescription {col} 2</item></list>
+        </p>
+      </scopecontent>.toString().replaceAll("\n", "")
+
+      val body =
+        s"""{
+         |  "assets": [
+         |    {
+         |      "citableReference": "$col",
+         |      "scopeContent": {
+         |        "description": "$description"
+         |      },
+         |      "title": "<unittitle>Test Title $col</unittitle>"
+         |    }
+         |  ]
+         |}
+         |""".stripMargin
+      col -> body
+    })
+    .toMap
+
+  private def checkDynamoTable(table: DynamoTable, collection: String, expectedId: String, parentPath: String): Assertion = {
+    table.id.toString should equal(expectedId)
+    table.name should equal(collection)
+    table.title should equal(s"Test Title $collection")
+    table.batchId should equal("testBatch")
+    table.`type` should equal("Folder")
+    table.fileSize.isEmpty should be(true)
+    table.parentPath should equal(parentPath)
+    table.description should equal(s"TestDescription $collection 1          \nTestDescription $collection 2")
+  }
+
+  "getDepartmentAndSeriesRows" should "return the correct values for series and department" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T"))
+      .thenRespond(bodyMap("T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST"))
+      .thenRespond(bodyMap("T TEST"))
+
+    val result = new DiscoveryService(baseUrl, backend, uuidIterator)
+      .getDepartmentAndSeriesRows(Input("testBatch", "", "", Option("T"), Option("T TEST")))
+      .unsafeRunSync()
+
+    val department = result.department
+    val series = result.series.head
+
+    checkDynamoTable(department, "T", uuids.head, "")
+    checkDynamoTable(series, "T TEST", uuids.tail.head, uuids.head)
+  }
+
+  "getDepartmentAndSeriesRows" should "return an error if the department reference doesn't match the input" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/A"))
+      .thenRespond(bodyMap("T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST"))
+      .thenRespond(bodyMap("T TEST"))
+
+    val ex = intercept[Exception] {
+      new DiscoveryService(baseUrl, backend, uuidIterator)
+        .getDepartmentAndSeriesRows(Input("testBatch", "", "", Option("A"), Option("T TEST")))
+        .unsafeRunSync()
+    }
+    ex.getMessage should equal("Cannot find asset with citeable reference A")
+  }
+
+  "getDepartmentAndSeriesRows" should "return an error if the series reference doesn't match the input" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T"))
+      .thenRespond(bodyMap("T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/A TEST"))
+      .thenRespond(bodyMap("T TEST"))
+
+    val ex = intercept[Exception] {
+      new DiscoveryService(baseUrl, backend, uuidIterator)
+        .getDepartmentAndSeriesRows(Input("testBatch", "", "", Option("T"), Option("A TEST")))
+        .unsafeRunSync()
+    }
+    ex.getMessage should equal("Cannot find asset with citeable reference A TEST")
+  }
+
+  "getDepartmentAndSeriesRows" should "return an error if the discovery API returns an error" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError()).whenAnyRequest
+      .thenRespondServerError()
+
+    val ex = intercept[Exception] {
+      new DiscoveryService(baseUrl, backend, uuidIterator)
+        .getDepartmentAndSeriesRows(Input("testBatch", "", "", Option("T"), Option("A TEST")))
+        .unsafeRunSync()
+    }
+    ex.getMessage should equal("statusCode: 500, response: Internal server error")
+  }
+
+  "getDepartmentAndSeriesRows" should "an unknown department if the department is missing" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
+
+    val result = new DiscoveryService(baseUrl, backend, uuidIterator)
+      .getDepartmentAndSeriesRows(Input("testBatch", "", "", None, Option("A TEST")))
+      .unsafeRunSync()
+    result.series.isDefined should equal(false)
+    val department = result.department
+    department.name should equal("Unknown")
+    department.title should equal("")
+    department.description should equal("")
+  }
+
+  "getDepartmentAndSeriesRows" should "an unknown department if the series is missing" in {
+    val backend: SttpBackendStub[IO, Fs2Streams[IO]] = SttpBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
+
+    val result = new DiscoveryService(baseUrl, backend, uuidIterator)
+      .getDepartmentAndSeriesRows(Input("testBatch", "", "", Option("T"), None))
+      .unsafeRunSync()
+    result.series.isDefined should equal(false)
+    val department = result.department
+    department.name should equal("Unknown")
+    department.title should equal("")
+    department.description should equal("")
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
@@ -60,7 +60,7 @@ class DiscoveryServiceTest extends AnyFlatSpec {
     table.name should equal(collection)
     table.title should equal(s"Test Title $collection")
     table.batchId should equal("testBatch")
-    table.`type`.value should equal("Folder")
+    table.`type`.toString should equal("Folder")
     table.fileSize.isEmpty should be(true)
     table.parentPath should equal(parentPath)
     table.description should equal(s"TestDescription $collection 1          \nTestDescription $collection 2")

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -229,7 +229,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     tableRequestItems.length should equal(6)
     checkDynamoItems(DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", "Folder", "Test Title A", "TestDescriptionA"))
     checkDynamoItems(DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", "Folder", "Test Title A 1", "TestDescriptionA 1"))
-    checkDynamoItems(DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}/", "TestName", "Folder", "TestTitle", ""))
+    checkDynamoItems(DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}", "TestName", "Folder", "TestTitle", ""))
     checkDynamoItems(DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", "Asset", "", ""))
     checkDynamoItems(
       DynamoTable("TEST", docxIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier", "Test.docx", "File", "TestTitle", "", Option(1))

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -1,0 +1,310 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.apache.commons.io.output.ByteArrayOutputStream
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import ujson.Obj
+import uk.gov.nationalarchives.Lambda._
+import uk.gov.nationalarchives.MetadataService.DynamoTable
+import upickle.default
+import upickle.default._
+
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.util.UUID
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
+
+  implicit val stateDataReader: default.Reader[StateData] = macroR[StateData]
+
+  override def beforeEach(): Unit = {
+    dynamoServer.resetAll()
+    dynamoServer.start()
+    s3Server.resetAll()
+    s3Server.start()
+    discoveryServer.resetAll()
+    discoveryServer.start()
+  }
+
+  val s3Server = new WireMockServer(9003)
+  val dynamoServer = new WireMockServer(9005)
+  val discoveryServer = new WireMockServer(9004)
+  val inputBucket = "input"
+  val uuids: List[String] = List(
+    "c7e6b27f-5778-4da8-9b83-1b64bbccbd03",
+    "61ac0166-ccdf-48c4-800f-29e5fba2efda"
+  )
+  implicit val sRequestFieldReader: Reader[DynamoSRequestField] = macroR[DynamoSRequestField]
+  implicit val nRequestFieldReader: Reader[DynamoNRequestField] = macroR[DynamoNRequestField]
+  implicit val itemReader: Reader[DynamoItem] = reader[Obj].map[DynamoItem] { json =>
+    DynamoItem(
+      read[DynamoSRequestField](json("batchId")),
+      read[DynamoSRequestField](json("id")),
+      json.obj.get("parentPath").map(pp => read[DynamoSRequestField](pp)).getOrElse(DynamoSRequestField("")),
+      read[DynamoSRequestField](json("name")),
+      read[DynamoSRequestField](json("type")),
+      if (json.obj.contains("fileSize")) Option(read[DynamoNRequestField](json("fileSize"))) else None,
+      json.obj.get("title").map(pp => read[DynamoSRequestField](pp)).getOrElse(DynamoSRequestField("")),
+      json.obj.get("description").map(pp => read[DynamoSRequestField](pp)).getOrElse(DynamoSRequestField(""))
+    )
+  }
+  implicit val tableItemReader: Reader[DynamoTableItem] = macroR[DynamoTableItem]
+  implicit val putRequestReader: Reader[DynamoPutRequest] = macroR[DynamoPutRequest]
+  implicit val requestItemReader: Reader[DynamoRequestItem] = macroR[DynamoRequestItem]
+  implicit val requestBodyReader: Reader[DynamoRequestBody] = macroR[DynamoRequestBody]
+  case class DynamoSRequestField(S: String)
+  case class DynamoNRequestField(N: Long)
+  case class DynamoItem(
+      batchId: DynamoSRequestField,
+      id: DynamoSRequestField,
+      parentPath: DynamoSRequestField,
+      name: DynamoSRequestField,
+      `type`: DynamoSRequestField,
+      fileSize: Option[DynamoNRequestField],
+      title: DynamoSRequestField,
+      description: DynamoSRequestField
+  )
+  case class DynamoTableItem(PutRequest: DynamoPutRequest)
+  case class DynamoPutRequest(Item: DynamoItem)
+  case class DynamoRequestItem(test: List[DynamoTableItem])
+  case class DynamoRequestBody(RequestItems: DynamoRequestItem)
+
+  private def stubNetworkRequests(dynamoTableName: String = "test"): (UUID, UUID, UUID, UUID) = {
+    val folderIdentifier = UUID.randomUUID()
+    val assetIdentifier = UUID.randomUUID()
+    val docxIdentifier = UUID.randomUUID()
+    val metadataFileIdentifier = UUID.randomUUID()
+    val folderMetadata: String =
+      s"""identifier,parentPath,name,title
+         |$folderIdentifier,,TestName,TestTitle""".stripMargin
+
+    val assetMetadata: String =
+      s"""identifier,parentPath,title
+         |$assetIdentifier,$folderIdentifier,TestAssetTitle""".stripMargin
+
+    val fileMetadata: String =
+      s"""identifier,parentPath,name,fileSize,title
+         |$docxIdentifier,$folderIdentifier/$assetIdentifier,Test.docx,1,TestTitle
+         |$metadataFileIdentifier,$folderIdentifier/$assetIdentifier,TEST-metadata.json,2,
+         |""".stripMargin
+
+    val manifestData: String =
+      s"""checksumdocx data/$docxIdentifier
+         |checksummetadata data/$metadataFileIdentifier
+         |""".stripMargin
+
+    dynamoServer.stubFor(
+      post(urlEqualTo("/"))
+        .withRequestBody(matchingJsonPath("$.RequestItems", containing(dynamoTableName)))
+        .willReturn(ok())
+    )
+
+    List(
+      ("folder-metadata.csv", folderMetadata),
+      ("asset-metadata.csv", assetMetadata),
+      ("file-metadata.csv", fileMetadata),
+      ("manifest-sha256.txt", manifestData)
+    ).map { case (name, responseCsv) =>
+      s3Server.stubFor(
+        head(urlEqualTo(s"/TEST/$name"))
+          .willReturn(
+            ok()
+              .withHeader("Content-Length", responseCsv.getBytes.length.toString)
+              .withHeader("ETag", "abcde")
+          )
+      )
+      s3Server.stubFor(
+        get(urlEqualTo(s"/TEST/$name"))
+          .willReturn(ok.withBody(responseCsv.getBytes))
+      )
+    }
+
+    List("A", "A 1").foreach(col => {
+      val body =
+        s"""{
+           |  "assets": [
+           |    {
+           |      "citableReference": "$col",
+           |      "scopeContent": {
+           |        "description": "<scopecontent><head>Head</head><p>TestDescription$col</p></scopecontent>"
+           |      },
+           |      "title": "<unittitle>Test Title $col</unittitle>"
+           |    }
+           |  ]
+           |}
+           |""".stripMargin
+
+      discoveryServer.stubFor(
+        get(urlEqualTo(s"/API/records/v1/collection/${col.replace(" ", "%20")}"))
+          .willReturn(okJson(body))
+      )
+    })
+    (folderIdentifier, assetIdentifier, docxIdentifier, metadataFileIdentifier)
+  }
+
+  case class IngestMapperTest() extends Lambda {
+    val creds: StaticCredentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"))
+    private val asyncS3Client: S3AsyncClient = S3AsyncClient
+      .crtBuilder()
+      .endpointOverride(URI.create("http://localhost:9003"))
+      .credentialsProvider(creds)
+      .region(Region.EU_WEST_2)
+      .build()
+    private val asyncDynamoClient: DynamoDbAsyncClient = DynamoDbAsyncClient
+      .builder()
+      .endpointOverride(URI.create("http://localhost:9005"))
+      .region(Region.EU_WEST_2)
+      .credentialsProvider(creds)
+      .build()
+    val uuidsIterator: Iterator[String] = uuids.iterator
+    override val metadataService: MetadataService = new MetadataService(DAS3Client[IO](asyncS3Client))
+    override val dynamo: DADynamoDBClient[IO] = new DADynamoDBClient[IO](asyncDynamoClient)
+    override val randomUuidGenerator: () => UUID = () => UUID.fromString(uuidsIterator.next())
+  }
+  "handleRequest" should "return the correct values from the lambda" in {
+    val (folderIdentifier, assetIdentifier, _, _) = stubNetworkRequests()
+    val inJson =
+      s"""{
+        |  "batchId": "TEST",
+        |  "s3Bucket": "$inputBucket",
+        |  "s3Prefix" : "TEST/",
+        |  "department": "A",
+        |  "series": "A 1"
+        |}""".stripMargin
+    val is = new ByteArrayInputStream(inJson.getBytes())
+    val os = new ByteArrayOutputStream()
+    IngestMapperTest().handleRequest(is, os, null)
+    val stateData = read[StateData](os.toByteArray.map(_.toChar).mkString)
+    val archiveFolders = stateData.archiveHierarchyFolders
+    archiveFolders.size should be(3)
+    archiveFolders.contains(folderIdentifier) should be(true)
+    archiveFolders.containsSlice(uuids.map(UUID.fromString)) should be(true)
+
+    stateData.contentFolders.isEmpty should be(true)
+
+    stateData.contentAssets.size should be(1)
+    stateData.contentAssets.head should equal(assetIdentifier)
+  }
+
+  "handleRequest" should "write the correct values to dynamo" in {
+    val (folderIdentifier, assetIdentifier, docxIdentifier, metadataIdentifier) = stubNetworkRequests()
+    val inJson =
+      s"""{
+         |  "batchId": "TEST",
+         |  "s3Bucket": "$inputBucket",
+         |  "s3Prefix" : "TEST/",
+         |  "department": "A",
+         |  "series": "A 1"
+         |}""".stripMargin
+    val is = new ByteArrayInputStream(inJson.getBytes())
+    val os = new ByteArrayOutputStream()
+    IngestMapperTest().handleRequest(is, os, null)
+    val dynamoRequestBodies = dynamoServer.getAllServeEvents.asScala.map(e => read[DynamoRequestBody](e.getRequest.getBodyAsString))
+    print(dynamoRequestBodies)
+    dynamoRequestBodies.length should equal(1)
+    val tableRequestItems = dynamoRequestBodies.head.RequestItems.test
+    def checkDynamoItems(expectedTable: DynamoTable) = {
+      val items = tableRequestItems.filter(_.PutRequest.Item.id.S == expectedTable.id.toString).map(_.PutRequest.Item)
+      items.size should equal(1)
+      val item = items.head
+      item.id.S should equal(expectedTable.id.toString)
+      item.name.S should equal(expectedTable.name)
+      item.title.S should equal(expectedTable.title)
+      item.parentPath.S should equal(expectedTable.parentPath)
+      item.batchId.S should equal(expectedTable.batchId)
+      item.description.S should equal(expectedTable.description)
+      item.fileSize.map(_.N) should equal(expectedTable.fileSize)
+      item.`type`.S should equal(expectedTable.`type`)
+    }
+    tableRequestItems.length should equal(6)
+    checkDynamoItems(DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", "Folder", "Test Title A", "TestDescriptionA"))
+    checkDynamoItems(DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", "Folder", "Test Title A 1", "TestDescriptionA 1"))
+    checkDynamoItems(DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}/", "TestName", "Folder", "TestTitle", ""))
+    checkDynamoItems(DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", "Asset", "", ""))
+    checkDynamoItems(
+      DynamoTable("TEST", docxIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier", "Test.docx", "File", "TestTitle", "", Option(1))
+    )
+    checkDynamoItems(
+      DynamoTable(
+        "TEST",
+        metadataIdentifier,
+        s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier",
+        "TEST-metadata.json",
+        "File",
+        "",
+        "",
+        Option(2),
+        Option("checksum"),
+        Option("txt")
+      )
+    )
+  }
+
+  "handleRequest" should "return an error if the discovery api is unavailable" in {
+    stubNetworkRequests()
+    discoveryServer.stop()
+    val inJson =
+      s"""{
+         |  "batchId": "TEST",
+         |  "s3Bucket": "$inputBucket",
+         |  "s3Prefix" : "TEST/",
+         |  "department": "A",
+         |  "series": "A 1"
+         |}""".stripMargin
+    val is = new ByteArrayInputStream(inJson.getBytes())
+    val os = new ByteArrayOutputStream()
+    val ex = intercept[Exception] {
+      IngestMapperTest().handleRequest(is, os, null)
+    }
+
+    ex.getMessage should equal("Exception when sending request: GET http://localhost:9004/API/records/v1/collection/A")
+  }
+
+  "handleRequest" should "return an error if the input files are not stored in S3" in {
+    stubNetworkRequests()
+    val inJson =
+      s"""{
+         |  "batchId": "TEST",
+         |  "s3Bucket": "$inputBucket",
+         |  "s3Prefix" : "INVALID/",
+         |  "department": "A",
+         |  "series": "A 1"
+         |}""".stripMargin
+    val is = new ByteArrayInputStream(inJson.getBytes())
+    val os = new ByteArrayOutputStream()
+    val ex = intercept[Exception] {
+      IngestMapperTest().handleRequest(is, os, null)
+    }
+
+    ex.getMessage should equal("null (Service: S3, Status Code: 404, Request ID: null)")
+  }
+
+  "handleRequest" should "return an error if the dynamo table doesn't exist" in {
+    stubNetworkRequests("invalidTable")
+    val inJson =
+      s"""{
+         |  "batchId": "TEST",
+         |  "s3Bucket": "$inputBucket",
+         |  "s3Prefix" : "TEST/",
+         |  "department": "A",
+         |  "series": "A 1"
+         |}""".stripMargin
+    val is = new ByteArrayInputStream(inJson.getBytes())
+    val os = new ByteArrayOutputStream()
+    val ex = intercept[Exception] {
+      IngestMapperTest().handleRequest(is, os, null)
+    }
+
+    ex.getMessage should equal("Service returned HTTP status code 404 (Service: DynamoDb, Status Code: 404, Request ID: null)")
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -196,7 +196,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     item.batchId.S should equal(expectedTable.batchId)
     item.description.S should equal(expectedTable.description)
     item.fileSize.map(_.N) should equal(expectedTable.fileSize)
-    item.`type`.S should equal(expectedTable.`type`.value)
+    item.`type`.S should equal(expectedTable.`type`.toString)
   }
 
   case class IngestMapperTest() extends Lambda {
@@ -244,13 +244,13 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     val tableRequestItems = dynamoRequestBodies.head.RequestItems.test
 
     tableRequestItems.length should equal(6)
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", Folder(), "Test Title A", "TestDescriptionA"))
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", Folder(), "Test Title A 1", "TestDescriptionA 1"))
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}", "TestName", Folder(), "TestTitle", ""))
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", Asset(), "", ""))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", Folder, "Test Title A", "TestDescriptionA"))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", Folder, "Test Title A 1", "TestDescriptionA 1"))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}", "TestName", Folder, "TestTitle", ""))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", Asset, "", ""))
     checkDynamoItems(
       tableRequestItems,
-      DynamoTable("TEST", docxIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier", "Test.docx", File(), "TestTitle", "", Option(1))
+      DynamoTable("TEST", docxIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier", "Test.docx", File, "TestTitle", "", Option(1))
     )
     checkDynamoItems(
       tableRequestItems,
@@ -259,7 +259,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
         metadataIdentifier,
         s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier",
         "TEST-metadata.json",
-        File(),
+        File,
         "",
         "",
         Option(2),

--- a/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
@@ -151,7 +151,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
       seriesIdOpt.map(seriesId =>
         checkTableRows(List(seriesId), 1, DynamoTable(batchId, seriesId, departmentId.toString, "series", "Folder", "series Title", "series Description"))
       )
-      checkTableRows(List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix/", folderMetadata.head.name, "Folder", folderMetadata.head.title, ""))
+      checkTableRows(List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix", folderMetadata.head.name, "Folder", folderMetadata.head.title, ""))
       checkTableRows(List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", assetMetadata.head.title, "Asset", "", ""))
       checkTableRows(
         List(fileIdOne),

--- a/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
@@ -135,7 +135,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
       val s3 = mockS3(testCsvWithHeaders)
 
       def table(id: UUID, tableType: String, parentPath: String) =
-        DynamoTable("batchId", id, parentPath, tableType, Folder(), s"$tableType Title", s"$tableType Description")
+        DynamoTable("batchId", id, parentPath, tableType, Folder, s"$tableType Title", s"$tableType Description")
 
       val batchId = "batchId"
       val folderId = UUID.randomUUID()
@@ -158,12 +158,12 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
       result.size should equal(5 + seriesIdOpt.size)
 
       val prefix = s"$departmentId${seriesIdOpt.map(id => s"/$id").getOrElse("")}"
-      checkTableRows(result, List(departmentId), 1, DynamoTable(batchId, departmentId, "", "department", Folder(), "department Title", "department Description"))
+      checkTableRows(result, List(departmentId), 1, DynamoTable(batchId, departmentId, "", "department", Folder, "department Title", "department Description"))
       seriesIdOpt.map(seriesId =>
-        checkTableRows(result, List(seriesId), 1, DynamoTable(batchId, seriesId, departmentId.toString, "series", Folder(), "series Title", "series Description"))
+        checkTableRows(result, List(seriesId), 1, DynamoTable(batchId, seriesId, departmentId.toString, "series", Folder, "series Title", "series Description"))
       )
-      checkTableRows(result, List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix", folderMetadata.head.name, Folder(), folderMetadata.head.title, ""))
-      checkTableRows(result, List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", assetMetadata.head.title, Asset(), "", ""))
+      checkTableRows(result, List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix", folderMetadata.head.name, Folder, folderMetadata.head.title, ""))
+      checkTableRows(result, List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", assetMetadata.head.title, Asset, "", ""))
       checkTableRows(
         result,
         List(fileIdOne),
@@ -173,7 +173,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
           assetId,
           s"$prefix/$folderId/$assetId",
           fileMetadata.head.name,
-          File(),
+          File,
           fileMetadata.head.title,
           "",
           Option(fileMetadata.head.fileSize),
@@ -190,7 +190,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
           assetId,
           s"$prefix/$folderId/$assetId",
           fileMetadata.last.name,
-          File(),
+          File,
           fileMetadata.last.title,
           "",
           Option(fileMetadata.last.fileSize),

--- a/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
@@ -1,0 +1,191 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import cats.implicits._
+import cats.effect.unsafe.implicits.global
+import fs2.data.csv.{CsvRowDecoder, DecoderError, DecoderResult, NoneF, RowDecoder, RowF}
+import org.mockito.stubbing.ScalaOngoingStubbing
+import org.mockito.{ArgumentMatchers, MockitoSugar}
+import org.reactivestreams.Publisher
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2, TableFor3}
+import reactor.core.publisher.Flux
+import uk.gov.nationalarchives.Lambda.Input
+import uk.gov.nationalarchives.MetadataService.{AssetMetadata, BagitManifest, DepartmentSeries, DynamoTable, FileMetadata, FolderMetadata}
+
+import java.nio.ByteBuffer
+import java.util.UUID
+
+class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenPropertyChecks {
+  case class Test(name: String, value: String)
+  case class TestCsvRowDecoder() extends CsvRowDecoder[Test, String] {
+    override def apply(row: RowF[Some, String]): DecoderResult[Test] = {
+      val result = for {
+        name <- row.as[String]("name")
+        value <- row.as[String]("value")
+      } yield Test(name, value)
+      result.left.map(_ => new DecoderError("Error decoding csv"))
+    }
+  }
+  case class TestRowDecoder() extends RowDecoder[Test] {
+    override def apply(row: RowF[NoneF, Nothing]): DecoderResult[Test] =
+      row.values.tail.headOption
+        .map(tail => Right(Test(row.values.head, tail)))
+        .getOrElse(Left(new DecoderError("Error decoding csv")))
+  }
+  implicit val testRowCsvDecoder: TestCsvRowDecoder = TestCsvRowDecoder()
+  implicit val testRowDecoder: TestRowDecoder = TestRowDecoder()
+
+  val testCsvWithHeaders = "name,value\ntestName1,testValue1\ntestName2,testValue2"
+  val testCsvWithoutHeaders = "testName1 testValue1\ntestName2 testValue2"
+
+  val invalidTestCsvWithHeaders = "invalid,header\ninvalidName,invalidValue"
+  val invalidTestCsvWithoutHeaders = "invalidValue"
+
+  def mockS3(responseText: String, returnError: Boolean = false): ScalaOngoingStubbing[IO[Publisher[ByteBuffer]]] = {
+    val s3 = mock[DAS3Client[IO]]
+    val stub = when(s3.download(ArgumentMatchers.eq("bucket"), ArgumentMatchers.eq("prefix/name")))
+    if (returnError) {
+      stub.thenThrow(new Exception("Key not found"))
+    } else {
+      stub.thenReturn(IO(Flux.just(ByteBuffer.wrap(responseText.getBytes))))
+    }
+  }
+
+  val testCsvTable: TableFor3[String, String, String] = Table(
+    ("id", "validCsv", "invalidCsv"),
+    ("With", testCsvWithHeaders, invalidTestCsvWithHeaders),
+    ("Without", testCsvWithoutHeaders, invalidTestCsvWithoutHeaders)
+  )
+
+  forAll(testCsvTable) { (id, validCsv, invalidCsv) =>
+    def parseCsv(s3: DAS3Client[IO], input: Input): List[Test] = {
+      val service = new MetadataService(s3)
+      (if (id == "With") {
+         service.parseCsvWithHeaders[Test](input, "name")
+       } else {
+         service.parseCsvWithoutHeaders[Test](input, "name")
+       }).unsafeRunSync()
+    }
+
+    s"parseCsv${id}Headers" should "return the correct row values" in {
+      val input = Input("testBatch", "bucket", "prefix/", Option("T"), Option("T TEST"))
+      val s3 = mockS3(validCsv)
+      val result = parseCsv(s3, input)
+
+      result.size should equal(2)
+      result.head.name should equal("testName1")
+      result.head.value should equal("testValue1")
+      result.last.name should equal("testName2")
+      result.last.value should equal("testValue2")
+    }
+
+    s"parseCsv${id}Headers" should "return an error if the csv is in an unexpected format" in {
+      val input = Input("testBatch", "bucket", "prefix/", Option("T"), Option("T TEST"))
+      val s3 = mockS3(invalidCsv)
+      val ex = intercept[DecoderError] {
+        parseCsv(s3, input)
+      }
+      ex.getMessage should equal("Error decoding csv")
+    }
+
+    s"parseCsv${id}Headers" should "return an error if the s3 key is not found" in {
+      val input = Input("testBatch", "bucket", "prefix/", Option("T"), Option("T TEST"))
+      val s3 = mockS3(validCsv, returnError = true)
+      val ex = intercept[Exception] {
+        parseCsv(s3, input)
+      }
+      ex.getMessage should equal("Key not found")
+    }
+  }
+
+  val departmentSeriesTable: TableFor2[UUID, Option[UUID]] = Table(
+    ("departmentId", "seriesId"),
+    (UUID.randomUUID(), Option(UUID.randomUUID())),
+    (UUID.randomUUID(), None)
+  )
+  forAll(departmentSeriesTable) { (departmentId, seriesIdOpt) =>
+    "metadataToDynamoTables" should s"return a list of tables with the correct prefix for department $departmentId and series ${seriesIdOpt.getOrElse("None")}" in {
+      val s3 = mockS3(testCsvWithHeaders)
+
+      def table(id: UUID, tableType: String, parentPath: String) =
+        DynamoTable("batchId", id, parentPath, tableType, "Folder", s"$tableType Title", s"$tableType Description")
+
+      val batchId = "batchId"
+      val folderId = UUID.randomUUID()
+      val assetId = UUID.randomUUID()
+      val fileIdOne = UUID.randomUUID()
+      val fileIdTwo = UUID.randomUUID()
+      val departmentTable = table(departmentId, "department", "")
+      val seriesTable = seriesIdOpt.map(id => table(id, "series", departmentId.toString))
+      val departmentAndSeries = DepartmentSeries(departmentTable, seriesTable)
+      val folderMetadata = List(FolderMetadata(folderId, "", "folderName", "folderTitle"))
+      val assetMetadata = List(AssetMetadata(assetId, folderId.toString, "assetTitle"))
+      val fileMetadata = List(
+        FileMetadata(fileIdOne, s"$folderId/$assetId", "fileName1.txt", 1, "fileTitle1"),
+        FileMetadata(fileIdTwo, s"$folderId/$assetId", "fileName2.pdf", 2, "fileTitle2")
+      )
+      val bagitManifests: List[BagitManifest] = fileMetadata.map(fm => BagitManifest(s"${fm.name}checksum", s"data/${fm.identifier}"))
+      val result =
+        new MetadataService(s3).metadataToDynamoTables(batchId, departmentAndSeries, folderMetadata ++ assetMetadata ++ fileMetadata, bagitManifests).unsafeRunSync()
+
+      result.size should equal(5 + seriesIdOpt.size)
+
+      def checkTableRows(ids: List[UUID], expectedSize: Int, expectedTable: DynamoTable) = {
+        val rows = result.filter(r => ids.contains(r.id))
+        rows.size should equal(expectedSize)
+        rows.map { row =>
+          ids.contains(row.id) should be(true)
+          row.name should equal(expectedTable.name)
+          row.title should equal(expectedTable.title)
+          row.parentPath should equal(expectedTable.parentPath)
+          row.batchId should equal(expectedTable.batchId)
+          row.description should equal(expectedTable.description)
+          row.fileSize should equal(expectedTable.fileSize)
+          row.`type` should equal(expectedTable.`type`)
+        }
+      }
+      val prefix = s"$departmentId${seriesIdOpt.map(id => s"/$id").getOrElse("")}"
+      checkTableRows(List(departmentId), 1, DynamoTable(batchId, departmentId, "", "department", "Folder", "department Title", "department Description"))
+      seriesIdOpt.map(seriesId =>
+        checkTableRows(List(seriesId), 1, DynamoTable(batchId, seriesId, departmentId.toString, "series", "Folder", "series Title", "series Description"))
+      )
+      checkTableRows(List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix/", folderMetadata.head.name, "Folder", folderMetadata.head.title, ""))
+      checkTableRows(List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", assetMetadata.head.title, "Asset", "", ""))
+      checkTableRows(
+        List(fileIdOne),
+        1,
+        DynamoTable(
+          batchId,
+          assetId,
+          s"$prefix/$folderId/$assetId",
+          fileMetadata.head.name,
+          "File",
+          fileMetadata.head.title,
+          "",
+          Option(fileMetadata.head.fileSize),
+          Option(s"${fileMetadata.head.name}checksum"),
+          Option(".txt")
+        )
+      )
+      checkTableRows(
+        List(fileIdTwo),
+        1,
+        DynamoTable(
+          batchId,
+          assetId,
+          s"$prefix/$folderId/$assetId",
+          fileMetadata.last.name,
+          "File",
+          fileMetadata.last.title,
+          "",
+          Option(fileMetadata.last.fileSize),
+          Option(s"${fileMetadata.head.name}checksum"),
+          Option(".pdf")
+        )
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This needs https://github.com/nationalarchives/da-aws-clients/pull/29 to merge and deploy before the tests will pass but the code is ready for review.

* Reads the input from the step function step
* Gets title and description for department and series from discovery
* Parses the folder metadata csv
* Parses the asset metadata csv
* Parses the file metadata csv
* Parses the manifest file
* Converts these into Dynamo case classes
* Updates dynamo with the values
* Writes the state data for the next step function step.
