### PR TITLE
Use the correct lambda name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_deploy.yml@main
     with:
-      lambda-name: ${{ github.event.inputs.environment }}-dr2-ingest-mapper
+      lambda-name: ${{ github.event.inputs.environment }}-ingest-mapper
       deployment-package: dr2-ingest-mapper.jar
       environment: ${{ github.event.inputs.environment }}
       to-deploy: ${{ github.event.inputs.to-deploy }}


### PR DESCRIPTION
The lambda name doesn't have dr2 in it. Neither do any of the others. It
won't deploy as is.
