### PR TITLE
DR2-1224 Use name if title is empty.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -64,7 +64,7 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
     } yield {
       val departmentTableEntry = departmentDiscoveryAsset
         .map(tableEntry)
-        .getOrElse(DynamoTable(input.batchId, randomUuidGenerator(), "", "Unknown", folder, "", ""))
+        .getOrElse(DynamoTable(input.batchId, randomUuidGenerator(), "", "Unknown", folder, "Unknown", ""))
       val seriesTableEntryOpt = seriesDiscoveryAsset
         .map(tableEntry)
         .map(_.copy(parentPath = departmentTableEntry.id.toString))

--- a/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
@@ -137,7 +137,7 @@ class DiscoveryServiceTest extends AnyFlatSpec {
     result.series.isDefined should equal(true)
     val department = result.department
     department.name should equal("Unknown")
-    department.title should equal("")
+    department.title should equal("Unknown")
     department.description should equal("")
   }
 
@@ -165,7 +165,7 @@ class DiscoveryServiceTest extends AnyFlatSpec {
     result.series.isDefined should equal(false)
     val department = result.department
     department.name should equal("Unknown")
-    department.title should equal("")
+    department.title should equal("Unknown")
     department.description should equal("")
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.util.Try
 
 class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
 
@@ -62,7 +63,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
       read[DynamoSRequestField](json("batchId")),
       read[DynamoSRequestField](json("id")),
       json.obj.get("parentPath").map(pp => read[DynamoSRequestField](pp)).getOrElse(DynamoSRequestField("")),
-      read[DynamoSRequestField](json("name")),
+      Try(read[DynamoSRequestField](json("name"))).getOrElse(DynamoSRequestField("")),
       read[DynamoSRequestField](json("type")),
       if (json.obj.contains("fileSize")) Option(read[DynamoNRequestField](json("fileSize"))) else None,
       json.obj.get("title").map(pp => read[DynamoSRequestField](pp)).getOrElse(DynamoSRequestField("")),
@@ -247,7 +248,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", Folder, "Test Title A", "TestDescriptionA"))
     checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", Folder, "Test Title A 1", "TestDescriptionA 1"))
     checkDynamoItems(tableRequestItems, DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}", "TestName", Folder, "TestTitle", ""))
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", Asset, "", ""))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "", Asset, "TestAssetTitle", ""))
     checkDynamoItems(
       tableRequestItems,
       DynamoTable("TEST", docxIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier", "Test.docx", File, "TestTitle", "", Option(1))
@@ -260,7 +261,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
         s"${uuids.head}/${uuids.tail.head}/$folderIdentifier/$assetIdentifier",
         "TEST-metadata.json",
         File,
-        "",
+        "TEST-metadata.json",
         "",
         Option(2),
         Option("checksum"),

--- a/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/MetadataServiceTest.scala
@@ -163,7 +163,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
         checkTableRows(result, List(seriesId), 1, DynamoTable(batchId, seriesId, departmentId.toString, "series", Folder, "series Title", "series Description"))
       )
       checkTableRows(result, List(folderId), 1, DynamoTable(batchId, folderId, s"$prefix", folderMetadata.head.name, Folder, folderMetadata.head.title, ""))
-      checkTableRows(result, List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", assetMetadata.head.title, Asset, "", ""))
+      checkTableRows(result, List(assetId), 1, DynamoTable(batchId, assetId, s"$prefix/$folderId", "", Asset, assetMetadata.head.title, ""))
       checkTableRows(
         result,
         List(fileIdOne),


### PR DESCRIPTION
Title can be empty when we're building the bag but Preservica won't
update a title to empty so it needs to be populated going into Dynamo.
If there's an empty title, this sets it as the name.
