### PR TITLE
Replace unicode decimals.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -20,10 +20,16 @@ import scala.xml.XML
 class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Streams[IO]], randomUuidGenerator: () => UUID) {
   private val folder = Folder
 
+  private def replaceUnicodeDecimals(input: String) =
+    "&#[0-9]+".r.replaceAllIn(input, _.matched.drop(2).toInt.toChar.toString)
+
   private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryCollectionAsset) = {
     val resources = for {
       xsltStream <- Resource.make(IO(getClass.getResourceAsStream("/transform.xsl")))(is => IO(is.close()))
-      inputStream <- Resource.make(IO(new ByteArrayInputStream(discoveryAsset.scopeContent.description.getBytes())))(is => IO(is.close()))
+      inputStream <- Resource.make {
+        val description = replaceUnicodeDecimals(discoveryAsset.scopeContent.description)
+        IO(new ByteArrayInputStream(description.getBytes()))
+      }(is => IO(is.close()))
       outputStream <- Resource.make(IO(new ByteArrayOutputStream()))(bos => IO(bos.close()))
     } yield (xsltStream, inputStream, outputStream)
     resources.use {

--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -20,15 +20,15 @@ import scala.xml.XML
 class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Streams[IO]], randomUuidGenerator: () => UUID) {
   private val folder = Folder
 
-  private def replaceUnicodeDecimals(input: String) =
+  private def replaceHtmlCodesWithUnicodeChars(input: String) =
     "&#[0-9]+".r.replaceAllIn(input, _.matched.drop(2).toInt.toChar.toString)
 
   private def stripHtmlFromDiscoveryResponse(discoveryAsset: DiscoveryCollectionAsset) = {
     val resources = for {
       xsltStream <- Resource.make(IO(getClass.getResourceAsStream("/transform.xsl")))(is => IO(is.close()))
       inputStream <- Resource.make {
-        val description = replaceUnicodeDecimals(discoveryAsset.scopeContent.description)
-        IO(new ByteArrayInputStream(description.getBytes()))
+        val descriptionWithHtmlCodesReplaced = replaceHtmlCodesWithUnicodeChars(discoveryAsset.scopeContent.description)
+        IO(new ByteArrayInputStream(descriptionWithHtmlCodesReplaced.getBytes()))
       }(is => IO(is.close()))
       outputStream <- Resource.make(IO(new ByteArrayOutputStream()))(bos => IO(bos.close()))
     } yield (xsltStream, inputStream, outputStream)

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -170,7 +170,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
            |    {
            |      "citableReference": "$col",
            |      "scopeContent": {
-           |        "description": "<scopecontent><head>Head</head><p>TestDescription$col</p></scopecontent>"
+           |        "description": "<scopecontent><head>Head</head><p>TestDescription$col with &#48</p></scopecontent>"
            |      },
            |      "title": "<unittitle>Test Title $col</unittitle>"
            |    }
@@ -244,8 +244,8 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     val tableRequestItems = dynamoRequestBodies.head.RequestItems.test
 
     tableRequestItems.length should equal(6)
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", Folder, "Test Title A", "TestDescriptionA"))
-    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", Folder, "Test Title A 1", "TestDescriptionA 1"))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.head), "", "A", Folder, "Test Title A", "TestDescriptionA with 0"))
+    checkDynamoItems(tableRequestItems, DynamoTable("TEST", UUID.fromString(uuids.tail.head), uuids.head, "A 1", Folder, "Test Title A 1", "TestDescriptionA 1 with 0"))
     checkDynamoItems(tableRequestItems, DynamoTable("TEST", folderIdentifier, s"${uuids.head}/${uuids.tail.head}", "TestName", Folder, "TestTitle", ""))
     checkDynamoItems(tableRequestItems, DynamoTable("TEST", assetIdentifier, s"${uuids.head}/${uuids.tail.head}/$folderIdentifier", "TestAssetTitle", Asset, "", ""))
     checkDynamoItems(


### PR DESCRIPTION
The description from discovery sometimes has
<extref href=&#34
in it. The XSLT gets very upset with this so as we're trying to convert
it to human readable text anyway, this replaces the decimal value with
the right character.
I've updated the tests so this is checked.
