### PR TITLE
DR2-1285 Combine bag-info and metadata json

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -65,7 +65,8 @@ class Lambda extends RequestStreamHandler {
       discoveryService <- DiscoveryService(config.discoveryApiUrl, randomUuidGenerator)
       departmentAndSeries <- discoveryService.getDepartmentAndSeriesRows(input)
       bagManifests <- metadataService.parseBagManifest(input)
-      metadataJson <- metadataService.parseMetadataJson(input, departmentAndSeries, bagManifests)
+      bagInfoJson <- metadataService.parseBagInfoJson(input)
+      metadataJson <- metadataService.parseMetadataJson(input, departmentAndSeries, bagManifests, bagInfoJson.headOption.getOrElse(Obj()))
       _ <- dynamo.writeItems(config.dynamoTableName, metadataJson)
     } yield {
 

--- a/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/MetadataService.scala
@@ -28,7 +28,9 @@ class MetadataService(s3: DAS3Client[IO]) {
     }
   }
 
-  def parseMetadataJson(input: Input, departmentAndSeries: DepartmentAndSeriesTableData, bagitManifests: List[BagitManifestRow]): IO[List[Obj]] = {
+  def parseBagInfoJson(input: Input): IO[List[Obj]] = parseFileFromS3(input, "bag-info.json", _.map(bagInfoJson => Obj.from(read(bagInfoJson).obj)))
+
+  def parseMetadataJson(input: Input, departmentAndSeries: DepartmentAndSeriesTableData, bagitManifests: List[BagitManifestRow], bagInfoJson: Obj): IO[List[Obj]] = {
     parseFileFromS3(
       input,
       "metadata.json",
@@ -54,11 +56,16 @@ class MetadataService(s3: DAS3Client[IO]) {
                     .map(Str)
                     .getOrElse(Null)
                 else Null
+              val metadataFromBagInfo: Obj = if (metadataEntry("type").str == "Asset") {
+                bagInfoJson
+              } else {
+                Obj()
+              }
               val metadataMap =
                 Map("batchId" -> Str(input.batchId), "parentPath" -> Str(path), "checksum_sha256" -> checksum, "fileExtension" -> fileExtension) ++ metadataEntry.obj.view
                   .filterKeys(_ != "parentId")
                   .toMap
-              Obj.from(metadataMap)
+              Obj.from(metadataFromBagInfo.value ++ metadataMap)
             } ++ departmentAndSeries.series.toList ++ List(departmentAndSeries.department)
           }
         }

--- a/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
@@ -42,7 +42,8 @@ object TestUtils {
       checksumSha256: Option[String] = None,
       fileExtension: Option[String] = None,
       customMetadataAttribute1: Option[String] = None,
-      customMetadataAttribute2: Option[String] = None
+      customMetadataAttribute2: Option[String] = None,
+      attributeUniqueToBagInfo: Option[String] = None
   )
 
   case class DynamoItem(


### PR DESCRIPTION
This will parse the bag-info.json file
If the entry in the metadata.json is an asset, the values from the
bag-info.json will be added to the row. If there are duplicate values,
the ones in metadata.json take priority.
