### PR TITLE
DR2-1377 Handle HTML quote code

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DiscoveryService.scala
@@ -42,7 +42,8 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
         transformer.transform(input, result)
         val newDescription = outputStream.toByteArray.map(_.toChar).mkString.trim
         val scopeContentWithNewDescription = discoveryAsset.scopeContent.copy(description = newDescription)
-        val titleWithoutBackslashes = XML.loadString(discoveryAsset.title.replaceAll("\\\\", "")).text
+        val titleWithoutHtmlCodes = replaceHtmlCodesWithUnicodeChars(discoveryAsset.title)
+        val titleWithoutBackslashes = XML.loadString(titleWithoutHtmlCodes.replaceAll("\\\\", "")).text
         IO(discoveryAsset.copy(scopeContent = scopeContentWithNewDescription, title = titleWithoutBackslashes)).handleError(_ => discoveryAsset)
       case _ => IO(discoveryAsset)
     }

--- a/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DiscoveryServiceTest.scala
@@ -49,7 +49,7 @@ class DiscoveryServiceTest extends AnyFlatSpec {
          |      "scopeContent": {
          |        "description": "$description"
          |      },
-         |      "title": "<unittitle>Test \\\\Title $col</unittitle>"
+         |      "title": "<unittitle type=&#34Title\\">Test \\\\Title $col</unittitle>"
          |    }
          |  ]
          |}

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -135,7 +135,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
            |      "scopeContent": {
            |        "description": "<scopecontent><head>Head</head><p>TestDescription$col with &#48</p></scopecontent>"
            |      },
-           |      "title": "<unittitle>Test Title $col</unittitle>"
+           |      "title": "<unittitle type=&#34Title\\">Test Title $col</unittitle>"
            |    }
            |  ]
            |}


### PR DESCRIPTION
It turns out that the title can have `unittitle type=&#34Title\"`
in it. We weren't replacing that for the title.

There's probably other strange things we'll have to handle but we'll
wait until they show themselves.
